### PR TITLE
Simplify pytorch init

### DIFF
--- a/src/stream_ml/pytorch/background/sloped.py
+++ b/src/stream_ml/pytorch/background/sloped.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import KW_ONLY, InitVar, dataclass
+from dataclasses import KW_ONLY, dataclass
 from typing import TYPE_CHECKING
 
 import torch as xp
@@ -41,10 +41,7 @@ class Sloped(ModelBase):
         f(x) = m(x - \frac{a + b}{2}) + \frac{1}{b-a}
     """
 
-    net: InitVar[nn.Module | None] = None
-
     _: KW_ONLY
-    array_namespace: InitVar[ArrayNamespace[Array]]
     param_names: ParamNamesField = ParamNamesField(
         (WEIGHT_NAME, (..., ("slope",))), requires_all_coordinates=False
     )
@@ -56,18 +53,12 @@ class Sloped(ModelBase):
     def __post_init__(
         self, array_namespace: ArrayNamespace[Array], net: nn.Module | None
     ) -> None:
-        super().__post_init__(array_namespace=array_namespace)
-
-        n_slopes = len(self.param_names) - 1  # (don't count the weight)
-
         # Initialize the network
-        if net is None:
-            self.nn = nn.Linear(1, n_slopes)
-            # Note; would prefer nn.Parameter(xp.zeros((1, n_slopes)) + 1e-5)
-            # as that has 1/2 as many params, but it's not callable.
-        else:
-            self.nn = net
-            # TODO: ensure n_out == n_slopes
+        # Note; would prefer nn.Parameter(xp.zeros((1, n_slopes)) + 1e-5)
+        # as that has 1/2 as many params, but it's not callable.
+        nnet = nn.Linear(1, len(self.coord_bounds)) if net is None else net
+        # TODO: ensure n_out == n_slopes
+        super().__post_init__(array_namespace=array_namespace, net=nnet)
 
         # Pre-compute the associated constant factors
         self._bma = xp.asarray(

--- a/src/stream_ml/pytorch/base.py
+++ b/src/stream_ml/pytorch/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import InitVar, dataclass
 from math import inf
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
 
@@ -18,6 +18,7 @@ __all__: list[str] = []
 
 if TYPE_CHECKING:
     from stream_ml.core.data import Data
+    from stream_ml.core.typing import ArrayNamespace
 
     Self = TypeVar("Self", bound="ModelBase")
 
@@ -25,6 +26,8 @@ if TYPE_CHECKING:
 @dataclass(unsafe_hash=True)
 class ModelBase(nn.Module, CoreModelBase[Array]):
     """Model base class."""
+
+    net: InitVar[nn.Module | None] = None
 
     DEFAULT_BOUNDS: ClassVar[PriorBounds] = SigmoidBounds(-inf, inf)
 
@@ -36,6 +39,19 @@ class ModelBase(nn.Module, CoreModelBase[Array]):
         # PyTorch needs to be initialized before attributes are assigned.
         nn.Module.__init__(self)
         return self
+
+    def __post_init__(
+        self, array_namespace: ArrayNamespace[Array], net: nn.Module | None
+    ) -> None:
+        super().__post_init__(array_namespace=array_namespace)
+
+        # Need to type hint the nn.Module
+        self.nn: nn.Module
+        if net is not None:
+            self.nn = net
+        else:
+            msg = "must provide a wrapped neural network."
+            raise ValueError(msg)
 
     # ========================================================================
     # ML


### PR DESCRIPTION
Move the nn.Module init to `__new__`. Now it’s always called first.
This greatly simplifies having subclasses with Module attributes.

Signed-off-by: nstarman <nstarkman@protonmail.com>


## PR Checklist

- [ ] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [ ] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
