### PR TITLE
change kde model to general callable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: text-unicode-replacement-char
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.261"
+    rev: "v0.0.265"
     hooks:
       - id: ruff
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,9 @@ ignore = [
   "COM812",  # TrailingCommaMissing
   "COM818",  # TrailingCommaOnBareTupleProhibited
   "COM819",  # TrailingCommaProhibited
+
+  # ruff (RUF)
+  "RUF009",  # do not perform function call in dataclass defaults
 ]
 
 [tool.ruff.flake8-tidy-imports]

--- a/src/stream_ml/pytorch/builtin/_isochrone.py
+++ b/src/stream_ml/pytorch/builtin/_isochrone.py
@@ -73,6 +73,8 @@ class IsochroneMVNorm(ModelBase):
     mag_names: tuple[str, ...] = ("g", "r")
     mag_err_names: tuple[str, ...] = ("g_err", "r_err")
 
+    approx_closest: bool = False  # Delta approximation
+
     def __post_init__(self, *args: Any, **kwargs: Any) -> None:
         super().__post_init__(*args, **kwargs)
         # Pairwise distance along gamma  # ([N], I, 1)
@@ -137,6 +139,7 @@ class IsochroneMVNorm(ModelBase):
         # log PDF: the (log)-Reimannian sum over the isochrone (log)-pdfs:
         # sum_i(deltagamma_i PDF(gamma_i))  -> translated
         # to log_pdfs
-        # return xp.logsumexp(self._ln_gamma_pdist + lnliks, 1)
-        # FIXME! approximating the marginalization with a delta function
-        return lnliks[xp.arange(0, len(lnliks)), xp.argmax(lnliks, 1)[:, 0]]
+        # OR approximating the marginalization with a delta function
+        if self.approx_closest:
+            return lnliks[xp.arange(0, len(lnliks)), xp.argmax(lnliks, 1)[:, 0]]
+        return xp.logsumexp(self._ln_gamma_pdist + lnliks, 1)


### PR DESCRIPTION
This also un-transposes the input and is no longer compatible with the plain `gaussian_kde`, but it is compatible with `RegularGridInterpolator` and (N, F) arrays.

## PR Checklist

- [ ] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [ ] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
