### PR TITLE
Allow kwargs in `astype` method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ where = ["src"]
 
   [[tool.mypy.overrides]]
     module = [
+      "asdf.*",
       "scipy.*",
       "torch.*",
     ]

--- a/src/stream_ml/pytorch/_connect/data.py
+++ b/src/stream_ml/pytorch/_connect/data.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 import numpy as np
@@ -12,9 +13,19 @@ from stream_ml.core._data import ASTYPE_REGISTRY, Data
 # --------  Register  ------------------------------------------------------
 
 
-def _from_ndarray_to_tensor(data: Data[np.ndarray[Any, Any]], /) -> Data[xp.Tensor]:
+def _from_tensor_to_tensor(data: Data[xp.Tensor], /, **kwargs: Any) -> Data[xp.Tensor]:
     """Convert from numpy.ndarray to torch.Tensor."""
-    return Data(xp.from_numpy(data.array).float(), names=data.names)
+    return replace(data, array=data.array.to(**kwargs))
+
+
+ASTYPE_REGISTRY[(xp.Tensor, xp.Tensor)] = _from_tensor_to_tensor
+
+
+def _from_ndarray_to_tensor(
+    data: Data[np.ndarray[Any, Any]], /, **kwargs: Any
+) -> Data[xp.Tensor]:
+    """Convert from numpy.ndarray to torch.Tensor."""
+    return replace(data, array=xp.asarray(data.array, **kwargs))
 
 
 ASTYPE_REGISTRY[(np.ndarray, xp.Tensor)] = _from_ndarray_to_tensor
@@ -27,10 +38,10 @@ except ImportError:
 else:
 
     def _from_ndarraytype_to_tensor(
-        data: Data[np.ndarray[Any, Any]], /
+        data: Data[np.ndarray[Any, Any]], /, **kwargs: Any
     ) -> Data[xp.Tensor]:
         """Convert from numpy.ndarray to torch.Tensor."""
-        return Data(xp.from_numpy(np.asarray(data.array)).float(), names=data.names)
+        return replace(data, array=xp.asarray(np.asarray(data.array), **kwargs))
 
     ASTYPE_REGISTRY[
         (asdf.tags.core.ndarray.NDArrayType, xp.Tensor)

--- a/src/stream_ml/pytorch/_connect/scaler.py
+++ b/src/stream_ml/pytorch/_connect/scaler.py
@@ -18,13 +18,13 @@ __all__: list[str] = []
 
 
 def standard_scaler_astype_tensor(
-    scaler: StandardScaler[Any],
+    scaler: StandardScaler[Any], /, **kwargs: Any
 ) -> StandardScaler[xp.Tensor]:
     """Register the `StandardScaler` class for `numpy.ndarray`."""
     return replace(
         scaler,
-        mean=xp.asarray(scaler.mean),
-        scale=xp.asarray(scaler.scale),
+        mean=xp.asarray(scaler.mean, **kwargs),
+        scale=xp.asarray(scaler.scale, **kwargs),
         names=scaler.names,
     )
 


### PR DESCRIPTION
Allow kwargs to be passed to `astype` methods, e.g. to change the dtype.