### PR TITLE
ensure ndarray is writable when -> tensor

### DIFF
--- a/src/stream_ml/pytorch/_connect/data.py
+++ b/src/stream_ml/pytorch/_connect/data.py
@@ -51,7 +51,9 @@ else:
         data: Data[np.ndarray[Any, Any]], /, **kwargs: Any
     ) -> Data[xp.Tensor]:
         """Convert from numpy.ndarray to torch.Tensor."""
-        return replace(data, array=xp.asarray(np.asarray(data.array), **kwargs))
+        array = np.array(data.array, copy=True, subok=False)
+        array.flags.writeable = True
+        return replace(data, array=xp.asarray(array, **kwargs))
 
     ASTYPE_REGISTRY[
         (asdf.tags.core.ndarray.NDArrayType, xp.Tensor)


### PR DESCRIPTION
Sometimes an ndarray gets unserialized in an unwritable state. This fixes that.

## PR Checklist

- [ ] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [ ] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
